### PR TITLE
Fix/specific movie url

### DIFF
--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -38,7 +38,7 @@ export default class App extends Component {
           exact
         />
         <Route
-          path="/:title"
+          path="/:title/:id"
           render={() => (
             <Container
               currentMovie={this.state.currentMovie}

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -26,29 +26,27 @@ export default class App extends Component {
     return (
       <div>
         <Header />
-        <Switch>
-          <Route
-            path="/"
-            render={() => (
-              <Container
-                movies={this.state.movies}
-                updateCurrentMovie={this.updateCurrentMovie}
-                error={this.state.error}
-              />
-            )}
-            exact
-          />
-          <Route
-            path="/:title"
-            render={() => (
-              <Container
-                currentMovie={this.state.currentMovie}
-                clearCurrentMovie={this.clearCurrentMovie}
-              />
-            )}
-            exact
-          />
-        </Switch>
+        <Route
+          path="/"
+          render={() => (
+            <Container
+              movies={this.state.movies}
+              updateCurrentMovie={this.updateCurrentMovie}
+              error={this.state.error}
+            />
+          )}
+          exact
+        />
+        <Route
+          path="/:title"
+          render={() => (
+            <Container
+              currentMovie={this.state.currentMovie}
+              clearCurrentMovie={this.clearCurrentMovie}
+            />
+          )}
+          exact
+        />
       </div>
     )
   }

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -9,18 +9,9 @@ export default class App extends Component {
     super()
     this.state = {
       movies: [],
-      currentMovie: null,
       error: false
     }
   }
-
-  updateCurrentMovie = (id) => (
-    this.setState({ currentMovie: id })
-  )
-
-  clearCurrentMovie = () => (
-    this.setState({ currentMovie: null })
-  )
 
   componentDidMount = () => {
     fetchData('https://rancid-tomatillos.herokuapp.com/api/v2/movies')
@@ -41,7 +32,6 @@ export default class App extends Component {
           render={() => (
             <Container
               movies={this.state.movies}
-              updateCurrentMovie={this.updateCurrentMovie}
               error={this.state.error}
             />
           )}
@@ -49,12 +39,11 @@ export default class App extends Component {
         />
         <Route
           path="/:title/:id"
-          render={({ match }) => {
-            return <Container
+          render={({ match }) => (
+            <Container
               currentMovie={match.params.id}
-              clearCurrentMovie={this.clearCurrentMovie}
             />
-          }}
+          )}
           exact
         />
       </div>

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import Header from '../Header/Header.js';
 import Container from '../Container/Container.js';
-import { Route, Switch } from 'react-router-dom';
+import { Route, useParams } from 'react-router-dom';
 import fetchData from '../../apiCalls.js';
 
 export default class App extends Component {
@@ -22,6 +22,16 @@ export default class App extends Component {
     this.setState({ currentMovie: null })
   )
 
+  componentDidMount = () => {
+    fetchData('https://rancid-tomatillos.herokuapp.com/api/v2/movies')
+    .then(data => {
+      this.setState({
+        movies: data.movies
+      });
+    })
+    .catch(err => this.setState({error: true}));
+  }
+
   render() {
     return (
       <div>
@@ -39,25 +49,16 @@ export default class App extends Component {
         />
         <Route
           path="/:title/:id"
-          render={() => (
-            <Container
-              currentMovie={this.state.currentMovie}
+          render={({ match }) => {
+            return <Container
+              currentMovie={match.params.id}
               clearCurrentMovie={this.clearCurrentMovie}
             />
-          )}
+          }}
           exact
         />
       </div>
     )
   }
 
-  componentDidMount = () => {
-    fetchData('https://rancid-tomatillos.herokuapp.com/api/v2/movies')
-    .then(data => {
-      this.setState({
-        movies: data.movies
-      });
-    })
-    .catch(err => this.setState({error: true}));
-  }
 }

--- a/src/components/Container/Container.js
+++ b/src/components/Container/Container.js
@@ -18,7 +18,6 @@ const Container = props => {
         poster_path={movie.poster_path}
         title={movie.title}
         average_rating={movie.average_rating}
-        updateCurrentMovie={props.updateCurrentMovie}
       />
     ));
     const loadingComponents = [<MovieLoader key={0}/>, <MovieLoader key={1}/>, <MovieLoader key={2}/>]
@@ -32,7 +31,6 @@ const Container = props => {
   } else {
     return <Details
       currentMovie={props.currentMovie}
-      clearCurrentMovie={props.clearCurrentMovie}
     />
   }
 }

--- a/src/components/Container/Container.js
+++ b/src/components/Container/Container.js
@@ -21,9 +21,7 @@ const Container = props => {
         updateCurrentMovie={props.updateCurrentMovie}
       />
     ));
-
     const loadingComponents = [<MovieLoader key={0}/>, <MovieLoader key={1}/>, <MovieLoader key={2}/>]
-
     return (
       <main>
         <section className='movie-grid'>

--- a/src/components/Details/Details.js
+++ b/src/components/Details/Details.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { Link } from 'react-router-dom';
-import { ErrorMsg } from '../ErrorMsg/ErrorMsg.js'; 
+import { ErrorMsg } from '../ErrorMsg/ErrorMsg.js';
 import DetailsLoader from '../DetailsLoader/DetailsLoader.js'
 import './Details.css'
 import fetchData from '../../apiCalls.js';
@@ -27,7 +27,7 @@ class Details extends Component {
   render = () => (
     this.state.error ? (
       <div className='error-box'>
-        <ErrorMsg /> 
+        <ErrorMsg />
         <Link className="back-button" to='/' onClick={this.props.clearCurrentMovie}>Back to Movies</Link>
       </div>
     ) : this.state.movie ? (

--- a/src/components/ErrorMsg/ErrorMsg.js
+++ b/src/components/ErrorMsg/ErrorMsg.js
@@ -1,9 +1,9 @@
-import React, { Component } from 'react';
+import React from 'react';
 
 export const ErrorMsg = () => (
   <div className='whole-error'>
     <h2 className='errorMsg'>Sorry, something went wrong!</h2>
-    <h3 className='later-text'>Please try again later!</h3> 
+    <h3 className='later-text'>Please try again later!</h3>
   </div>
 )
 

--- a/src/components/Movie/Movie.js
+++ b/src/components/Movie/Movie.js
@@ -3,10 +3,11 @@ import { Link } from 'react-router-dom';
 import './Movie.css';
 
 const Movie = ({ poster_path, title, average_rating, updateCurrentMovie, id }) => {
+  const cleanTitle = title.replaceAll(/[^a-zA-Z0-9]/g, '').replaceAll(' ', '');
   return (
     <article className="mini-movie">
       <Link
-        to={`/${title}/${id}`}
+        to={`/${cleanTitle}/${id}`}
         className="movie-wrapper"
         onClick={() => updateCurrentMovie(id)}
       >

--- a/src/components/Movie/Movie.js
+++ b/src/components/Movie/Movie.js
@@ -2,14 +2,13 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import './Movie.css';
 
-const Movie = ({ poster_path, title, average_rating, updateCurrentMovie, id }) => {
+const Movie = ({ poster_path, title, average_rating, id }) => {
   const cleanTitle = title.replaceAll(/[^a-zA-Z0-9]/g, '').replaceAll(' ', '');
   return (
     <article className="mini-movie">
       <Link
         to={`/${cleanTitle}/${id}`}
         className="movie-wrapper"
-        onClick={() => updateCurrentMovie(id)}
       >
         <img
           style={{

--- a/src/components/Movie/Movie.js
+++ b/src/components/Movie/Movie.js
@@ -6,7 +6,7 @@ const Movie = ({ poster_path, title, average_rating, updateCurrentMovie, id }) =
   return (
     <article className="mini-movie">
       <Link
-        to={`/${id}`}
+        to={`/${title}/${id}`}
         className="movie-wrapper"
         onClick={() => updateCurrentMovie(id)}
       >


### PR DESCRIPTION
## Is this a fix or a feature?
- This is a fix

## What is the change/fix?
- This fixes the problem of going to a direct URL and seeing an error message
- App state no longer tracks currentMovie
- Rather the route pulls the id from match.params.id 

## Where should the reviewer start?
- App.js

## How should this be tested?
- Make sure you can load a movie from a direct URL, navigate back to all movies, and click on another movie
- Make sure you can not find remnants of the event handlers that update currentMovie state as they should be removed

## Screenshots(if appropriate)

## This PR is related to which issues:
Closes #33